### PR TITLE
Fix module file path candidates algorithm

### DIFF
--- a/R/info.r
+++ b/R/info.r
@@ -81,13 +81,7 @@ find_global_mod = function (spec, caller) {
 #' given preference, and upper-case file extensions are discouraged).
 #' @keywords internal
 find_in_path = function (spec, base_paths) {
-    mod_path_prefix = merge_path(spec$prefix)
-    ext = c('.r', '.R')
-    # TODO: Write unit test that ensures the module is found in the correct
-    # order of preference of paths, when multiple possibilities exist.
-    simple_mod = file.path(mod_path_prefix, paste0(spec$name, ext))
-    nested_mod = file.path(mod_path_prefix, spec$name, paste0('__init__', ext))
-    candidates = map(file.path, base_paths, c(simple_mod, nested_mod))
+    candidates = mod_file_candidates(spec, base_paths)
     hits = map(file.exists, candidates)
     which_base = which(map_lgl(any, hits))[1L]
 
@@ -101,4 +95,12 @@ find_in_path = function (spec, base_paths) {
     path = candidates[[which_base]][hits[[which_base]]][1L]
     base_path = base_paths[which_base]
     mod_info(spec, normalizePath(path))
+}
+
+mod_file_candidates = function (spec, base_paths) {
+    mod_path_prefix = merge_path(spec$prefix)
+    ext = c('.r', '.R')
+    simple_mod = file.path(mod_path_prefix, paste0(spec$name, ext))
+    nested_mod = file.path(mod_path_prefix, spec$name, paste0('__init__', ext))
+    map(file.path, base_paths, list(c(simple_mod, nested_mod)))
 }

--- a/tests/testthat/test-find.r
+++ b/tests/testthat/test-find.r
@@ -41,3 +41,21 @@ test_that('local path is searched in module', {
     expect_paths_equal(rel$path_in_fun(), nested_path)
     expect_paths_equal(rel$path_in_nested_fun(), nested_path)
 })
+
+test_that('all module file candidates are found', {
+    # See <https://github.com/klmr/box/issues/174>
+    spec = parse_spec(quote(a/b), '')
+    paths = c('x', 'y')
+    candidates = mod_file_candidates(spec, paths)
+    expected = c(
+        'x/a/b.r',
+        'x/a/b.R',
+        'x/a/b/__init__.r',
+        'x/a/b/__init__.R',
+        'y/a/b.r',
+        'y/a/b.R',
+        'y/a/b/__init__.r',
+        'y/a/b/__init__.R'
+    )
+    expect_setequal(unlist(candidates), expected)
+})


### PR DESCRIPTION
The algorithm for calculating candidate module file paths based on a spec and the search paths was broken and, instead of enumerating all possible combinations of (nested or flat) module files and search paths, paired up paths with simple vs. nested module file candidates.

Fixes #174.