### PR TITLE
Attach names starting with a dot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # box (devel)
 
+* Fix: Attach names starting with a dot (#186)
+
+
 # box 1.0.0
 
 Complete rewrite; see the [migration

--- a/R/use.r
+++ b/R/use.r
@@ -371,7 +371,7 @@ mod_export_names = function (info, mod_ns) {
 
 #' @rdname importing
 attach_to_caller = function (spec, mod_exports, caller) {
-    attach_list = attach_list(spec, ls(mod_exports))
+    attach_list = attach_list(spec, names(mod_exports))
     if (is.null(attach_list)) return()
 
     import_env = find_import_env(caller, spec)

--- a/tests/testthat/mod/a.r
+++ b/tests/testthat/mod/a.r
@@ -63,6 +63,9 @@ which = function () '/a'
 #' @export
 encoding_test = function () '☃' # U+2603: SNOWMAN
 
+#' @export
+.hidden = 1L
+
 # Test cases for the issue 42. The semantics of the functions don’t matter so I
 # am using whimsical place-holders. What matters is whether or not the functions
 # get exported as operators.

--- a/tests/testthat/test-z-attach.r
+++ b/tests/testthat/test-z-attach.r
@@ -4,10 +4,21 @@ context('attaching')
 
 test_mod_envname = 'mod:mod/a'
 
-test_that('attach works locally', {
+test_that('attach works locally inside module', {
     box::use(mod/no_exports)
     # `no_exports` attaches `a`. So check that `a` is *not* attached here.
-    expect_false(test_mod_envname %in% search())
+    expect_not_in(test_mod_envname, search())
+    expect_false(exists('modname'))
+})
+
+test_that('attach works locally inside function', {
+    f = function () {
+        box::use(mod/a[...])
+        expect_true(exists('modname'))
+    }
+
+    f()
+    expect_false(exists('modname'))
 })
 
 test_that('module can be attached to global environment', {
@@ -19,6 +30,7 @@ test_that('module can be attached to global environment', {
         expect_true(mod_path %in% names(box:::loaded_mods))
         expect_equal(search()[2L], environmentName(a))
     })
+    rm(searchlen, envir = .GlobalEnv)
 })
 
 test_that('module can be detached', {
@@ -26,6 +38,12 @@ test_that('module can be detached', {
     parent = as.environment(3L)
     detach(test_mod_envname, character.only = TRUE)
     expect_identical(as.environment(2L), parent)
+})
+
+test_that('hidden names can be attached', {
+    expect_false(exists('.hidden'))
+    box::use(mod/a[...])
+    expect_true(exists('.hidden'))
 })
 
 test_that('unloading a module detaches it', {


### PR DESCRIPTION
Fix the current behaviour of not attaching exported names starting with a dot. For instance, the previous version would cause the following:

```r
box::use(dplyr[...])
.data
# Error: object '.data' not found
```

With this fix, accessing the unqualified name `.data` after attaching all names in ‘dplyr’ works correctly.