### PR TITLE
Add better support for ‘testthat’

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # box (devel)
 
+* Add explicit support for ‘testthat’ (#188)
+
+
 # box 1.0.0
 
 Complete rewrite; see the [migration

--- a/R/loaded.r
+++ b/R/loaded.r
@@ -130,6 +130,7 @@ set_script_path = function (path) {
 #' \enumerate{
 #'  \item Path explicitly set via \code{set_script_path}
 #'  \item Path of a running document/application (\pkg{knitr}, \pkg{Shiny})
+#'  \item Path of unit test cases (\pkg{testthat})
 #'  \item Code invoked as \command{Rscript script.r}
 #'  \item Code invoked as \command{R CMD BATCH script.r}
 #'  \item Script run interactively (use \code{getwd()})
@@ -160,7 +161,8 @@ script_path = function () {
 }
 
 #' @return \code{knitr_path} returns the directory in which the currently knit
-#' document is run, or \code{NULL} if not called from within a knitr document.
+#' document is run, or \code{NULL} if not called from within a \pkg{knitr}
+#' document.
 #' @rdname path
 knitr_path = function () {
     if (! 'knitr' %in% loadedNamespaces()) return(NULL)
@@ -169,13 +171,18 @@ knitr_path = function () {
     if (! is.null(knitr_input)) dirname(knitr_input)
 }
 
-#' @return \code{shiny_path} returns the directory in which a Shiny application
-#' is running, or \code{NULL} if not called from within a Shiny application.
+#' @return \code{shiny_path} returns the directory in which a \pkg{Shiny}
+#' application is running, or \code{NULL} if not called from within a
+#' \pkg{Shiny} application.
 #' @rdname path
 shiny_path = function () {
     if ('shiny' %in% loadedNamespaces() && shiny::isRunning()) getwd()
 }
 
+#' @return \code{testthat_path} returns the directory in which \pkg{testthat}
+#' code is being executed, or \code{NULL} if not called from within a
+#' \pkg{testthat} test case.
+#' @rdname path
 testthat_path = function () {
     if (identical(Sys.getenv("TESTTHAT"), "true")) getwd()
 }

--- a/R/loaded.r
+++ b/R/loaded.r
@@ -144,6 +144,8 @@ script_path = function () {
 
     if (! is.null((shiny_path = shiny_path()))) return(shiny_path)
 
+    if (! is.null((testthat_path = testthat_path()))) return(testthat_path)
+
     args = commandArgs()
 
     file_arg = grep('--file=', args)
@@ -172,4 +174,8 @@ knitr_path = function () {
 #' @rdname path
 shiny_path = function () {
     if ('shiny' %in% loadedNamespaces() && shiny::isRunning()) getwd()
+}
+
+testthat_path = function () {
+    if (identical(Sys.getenv("TESTTHAT"), "true")) getwd()
 }

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -31,6 +31,8 @@ navbar:
             text: Articles
             menu:
                 - text: General topics
+                - text: Testing modules
+                  href: articles/testing.html
                 - text: Using compiled code
                   href: articles/compiled-code.html
                 - text: Modules and packages compared

--- a/tests/testthat/helper-callr.r
+++ b/tests/testthat/helper-callr.r
@@ -5,8 +5,10 @@ r_cmdline = function (cmd, ...) {
         'support', 'rprofile.r'
     )
     args = c('--no-save', '--no-restore', ...)
+    # Unset `TESTTHAT` since otherwise ‘box’ thinks that tests are being run
+    # from inside ‘testthat’, and fudges the local search path.
     sprintf(
-        'R_ORIGINAL_PROFILE_USER="$R_PROFILE_USER" R_PROFILE_USER="%s" %s %s',
+        'TESTTHAT= R_ORIGINAL_PROFILE_USER="$R_PROFILE_USER" R_PROFILE_USER="%s" %s %s',
         rprofile, cmd, paste(shQuote(args), collapse = ' ')
     )
 }

--- a/vignettes/bio/__tests__/__init__.r
+++ b/vignettes/bio/__tests__/__init__.r
@@ -1,2 +1,5 @@
 box::use(testthat[...])
-test_dir(box::file())
+
+.on_load = function (ns) {
+    test_dir(box::file())
+}

--- a/vignettes/bio/__tests__/helper-module.r
+++ b/vignettes/bio/__tests__/helper-module.r
@@ -1,5 +1,1 @@
-# Necessary (for now) since testthat manually sets the working dir.
-box::set_script_path('../seq.r')
-
-# Load the module to be tested
-box::use(./seq[...])
+box::use(../seq[...])

--- a/vignettes/bio/seq.r
+++ b/vignettes/bio/seq.r
@@ -76,4 +76,6 @@ table = function (seq) {
     set_names(lapply(nucleotides, base::table, dnn = NULL), names(seq))
 }
 
-if (is.null(box::name())) box::use(./`__tests__`)
+if (is.null(box::name())) {
+    box::use(./`__tests__`)
+}

--- a/vignettes/testing.rmd
+++ b/vignettes/testing.rmd
@@ -1,0 +1,199 @@
+---
+title: "Testing modules"
+author: Konrad Rudolph
+date: "`r Sys.Date()`"
+output:
+    rmarkdown::html_vignette:
+        toc: true
+    md_document:
+        variant: gfm
+vignette: >
+    %\VignetteEngine{knitr::rmarkdown}
+    %\VignetteIndexEntry{Testing modules}
+    %\VignetteEncoding{UTF-8}
+---
+```{r include = FALSE}
+devtools::load_all()
+box::use(./source_file)
+```
+
+## Testing is crucial
+
+Writing tests to ensure code correctness is a crucial part of developing robust
+software. This is especially true for dynamic languages such as R, which lack
+some of the tools that ensure correctness in statically checked programming
+languages.
+
+‘box’ does not dictate a specific style of testing, and different kinds of
+testing are appropriate in different situations. However, the following article
+suggests a structure for the test accompanying a module which I have found to
+work well.
+
+Following the suggested structure causes the implementation and the tests of
+each module to be located in paths next to each other. This structure is found
+in several other conventions across programming languages; but it differs
+somewhat from the convention of R packages (where all implementation code is in
+a separate directory from all testing code), and differs drastically from the
+convention found for instance in Java. That said, it should be possible to make
+a Java-like test project work with ‘box’, too.
+
+
+## Support for existing testing frameworks
+
+‘box’ is agnostic regarding the testing framework. The following example employs
+the widely used ‘[testthat][]’ unit testing package, but other frameworks exist,
+and should also work.
+
+This example uses the [`bio/seq`](bio/seq.r) module from the _[Getting
+started][]_ vignette. To enable unit testing, this module contains the following
+code at the very end:
+
+```{r eval = FALSE}
+if (is.null(box::name())) {
+    box::use(./`__tests__`)
+}
+```
+
+This allows us to run the tests by running the module source code from the
+command line, e.g. via
+
+```bash
+Rscript bio/seq.r
+```
+
+… or inside an IDE such as RStudio by choosing the menu item “Tools” › “Jobs” ›
+“Start Local Job…” ^[It may be tempting to instead use the “Source” button but
+doing so is problematic; see the section “A note on RStudio and other IDEs”!].
+This works because `box::name()` returns the name of the module from which this
+function is called. But if the function is invoked from code that wasn’t loaded
+via `box::use()` (as is the case here), its value is `NULL`. In other words,
+`is.null(box::name())` is a way of testing whether the code currently being run
+is loaded as a module, or executed directly.
+
+The code inside the `if` imports the `__tests__` submodule: that’s where we put
+the unit tests. The name `__tests__` is a convention. You’re free to choose a
+different name, but I recommend sticking with this convention. Note that
+`__tests__` is not a valid R variable name; that’s why it needs to be written in
+backticks, i.e. the qualified local module name is ``./`__tests__` ``.
+
+In this case, the `__tests__` submodule consists of a directory with the
+following contents:
+
+* `__tests__/`
+    * [`__init__.r`](bio/__tests__/__init__.r)
+    * [`helper-module.r`](bio/__tests__/helper-module.r)
+    * individual test files
+
+The `__init__.r` file corresponds closely to the file `tests/testthat.R` in a
+standard R package structure. It loads ‘testthat’ and launches the tests:
+
+```{r file = 'bio/__tests__/__init__.r'}
+```
+
+This first loads and attaches the ‘testthat’ package. Although attaching is not
+strictly necessary, ‘testthat’ code is a lot more readable without cluttering
+the code with explicit name qualifications.
+
+Next it invokes `test_dir()` and passes the tests’ directory via
+`box::file()` inside the module’s `.on_load()` hook — remember that only
+declarations should be at file level inside a module! All code execution should
+happen inside functions.
+
+
+The `helper-module.r` file is a ‘testthat’ helper; these are sourced
+automatically by ‘testthat’ in the environment where the tests are run. We use
+this mechanism to load our module in the test environment:
+
+```{r file = 'bio/__tests__/helper-module.r'}
+```
+
+And, again, attaching isn’t strictly necessary here. Note also that, depending
+on how the tests are run, this helper file might not be needed, since executing
+the module script file itself already loads the module contents into the global
+namespace; however, not all ways of loading the tests do this; for instance,
+RStudio’s “Start Local Job” doesn’t. So having this helper is sometimes
+necessary, and never hurts.
+
+With this set-up, the actual unit test files look exactly like regular
+‘testthat’ test files. For instance, here’s `__tests__/test-seq.r`:
+
+```{r file = 'bio/__tests__/test-seq.r'}
+```
+
+
+### A note on RStudio and other IDEs
+
+Most IDEs have an option to “Source” a local file. When doing this it may *seem*
+as if the tests are correctly run, but this isn’t actually the case! This is
+because `box::use()` doesn’t reload code that has already been loaded
+previously; instead, it uses an already loaded, cached version. This means that
+running the tests via the “Source” button risks running an outdated version of
+the tests, or the module, or both, after modifying their code.
+
+To avoid this, always execute the test module in a new R session. In RStudio,
+the easiest way of doing this is by running it as a job, via the menu “Tools” ›
+“Jobs” › “Start Local Job…” (or using the option “Source as Local Job…” in the
+“Source” drop-down).
+
+
+## Test interfaces, not implementation details
+
+One big difference between testing module code and testing package code is that,
+with the testing structure laid out above, the testing code only sees the
+module’s public interface, it does not get access to the internal module
+implementation.^[Depending on how it’s invoked; but we shouldn’t make
+assumptions. In particular, when invoked as a job in RStudio, the test module is
+loaded via the test helper, and thus the module internals are not visible.]
+
+This is *by design*: the idea is that we want to test the *observable behaviour*
+rather than the (purely incidental) current implementation, which might be
+changed. This is the way unit testing works in many other environments, and how
+it is often recommended.
+
+But I realise that this may not always be appropriate. Sometimes we *need* to
+test implementation details. There are essentially two workarounds for this. For
+the moment, I have not yet developed a strong preference for either of these
+methods.
+
+1. Put the tests into the module files themselves.
+
+    ```{r eval = FALSE}
+    # mymod.r
+
+    this_works = function () TRUE
+
+    if (is.null(box::name())) {
+        box::use(testthat[...])
+
+        # Define tests
+
+        test_that('implementation detail X works', {
+            expect_true(this_works())
+        })
+
+        # Invoke tests
+
+        test_file(box::file())
+    }
+    ```
+
+2. Get access to the private module namespace for testing. When loading a module
+   with `box::use()`, the module object has an attribute `namespace` that holds
+   the private module namespace. It generally shouldn’t be accessed by client
+   code, but access by the testing code for a module is entirely legitimate:
+
+    ```{r eval = FALSE}
+    # __tests__/test-something.r
+
+    box::use(../mymod)
+
+    impl = attr(mymod, 'namespace')
+
+    test_that('implementation detail X works', {
+        expect_true(impl$this_works())
+    })
+    ```
+
+
+[testthat]: https://testthat.r-lib.org/
+[Getting started]: box.html


### PR DESCRIPTION
This PR adds a check for ‘testthat’ when determining the local module search path. This makes it easier to load modules inside ‘testhat’ test code, and thus to write unit tests for modules.

Resolves #188.