### PR TITLE
Switch test to use devtools:::yesno rather than devtools:::indent

### DIFF
--- a/tests/testthat/test-pkg.r
+++ b/tests/testthat/test-pkg.r
@@ -140,8 +140,8 @@ test_that('non-existent aliases raise error', {
 })
 
 test_that('only exported things can be attached', {
-    expect_in('indent', ls(getNamespace('devtools')))
-    expect_error(box::use(devtools[indent]), 'not exported')
+    expect_in('yesno', ls(getNamespace('devtools')))
+    expect_error(box::use(devtools[yesno]), 'not exported')
 })
 
 test_that('packages that attach things are not aliased', {


### PR DESCRIPTION
The latter internal function was removed in
https://github.com/r-lib/devtools/commit/467d51fa29883646622774a99abb1ac050365d36,
so subsequently this test in box now fails.

We plan to submit devtools to CRAN in the next few days, so subsequent to that submission you will have to update box on CRAN with this change to avoid test failures.