### PR TITLE
Fix segfault in R ≤ 3.6.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # box (development version)
 
+* Fix: prevent segfault in R ≤ 3.6.1 caused by missing declaration of internal R
+    symbol (#213)
 * Fix: Allow exporting modules that were previously imported using a different
     prefix (#211)
 * Enhancement: Add standard module for core R packages (#200)

--- a/src/lookup.c
+++ b/src/lookup.c
@@ -1,6 +1,12 @@
 #define R_NO_REMAP
 #include "Rinternals.h"
 #include "R_ext/Parse.h"
+#include "Rversion.h"
+
+#if R_VERSION < R_Version(3, 6, 2)
+// Declaration is internal before R 3.6.2.
+SEXP Rf_installTrChar(SEXP);
+#endif
 
 static SEXP parent_frame(void);
 static SEXP sys_call(SEXP parent);


### PR DESCRIPTION
Declare missing symbol `Rf_installTrChar`, which was not declared in `RInternals.h` until R.6.2 and thus causes the compiler to choose a different, mismatching function prototype.

Fixes #213.