### PR TITLE
Refactor messages

### DIFF
--- a/R/box-package.r
+++ b/R/box-package.r
@@ -80,23 +80,20 @@ called_from_example = function () {
         called_from_example()
     ) return()
 
-    template = paste0(
-        'The %s package is not supposed to be attached.\n\n',
-        'Please consult the user guide at %s.'
-    )
-    help = sprintf('`vignette(\'%s\', package = \'%s\')`', pkgname, pkgname)
     is_bad_call = function (call) {
-        c = call[[1L]]
-        identical(c, quote(library)) || identical(c, quote(require))
+        as.character(call[[1L]]) %in% c('library', 'require')
     }
+
     # Deparsed to silence spurious `R CMD check` warnign
-    default = parse(text = 'library(box)')[[1L]]
+    default = call('library', quote(box))
     bad_call = Filter(is_bad_call, sys.calls())[1L][[1L]] %||% default
-    cond = structure(
-        list(message = sprintf(template, shQuote(pkgname), help), call = bad_call),
-        class = c('box_attach_error', 'error', 'condition')
+    throw(
+        'The {pkgname;\'} package is not supposed to be attached.\n\n',
+        'Please consult the user guide at `{vignette}`.',
+        vignette = call('vignette', pkgname, package = pkgname),
+        call = bad_call,
+        subclass = 'box_attach_error'
     )
-    stop(cond)
 }
 
 .onLoad = function (libname, pkgname) {

--- a/R/env.r
+++ b/R/env.r
@@ -42,24 +42,24 @@ make_imports_env = function (info) {
     )
 }
 
-legacy_warn_msg = paste0(
-    'Using %s inside a module may cause issues; see the FAQ at',
-    '`vignette(\'faq\', \'box\')` for details.'
+legacy_warn_msg = c(
+    'Using {call;"} inside a module may cause issues; see the FAQ at ',
+    '`{call("vignette", "faq", package = "box")}` for details.'
 )
 
 box_library = function (...) {
-    warning(sprintf(legacy_warn_msg, dQuote('library')))
+    warning(fmt(legacy_warn_msg, call = 'library'))
     eval.parent(`[[<-`(match.call(), 1L, library))
 }
 
 box_require = function (...) {
-    warning(sprintf(legacy_warn_msg, dQuote('require')))
+    warning(fmt(legacy_warn_msg, call = 'require'))
     eval.parent(`[[<-`(match.call(), 1L, require))
 }
 
 box_source = function (file, local = FALSE, ...) {
     if (is.logical(local) && ! local) {
-        warning(sprintf(legacy_warn_msg, dQuote('source')))
+        warning(fmt(legacy_warn_msg, call = 'source'))
     }
     eval.parent(`[[<-`(match.call(), 1L, source))
 }

--- a/R/env.r
+++ b/R/env.r
@@ -160,7 +160,7 @@ strict_extract = function (e1, e2) {
 `print.box$mod` = function (x, ...) {
     spec = attr(x, 'spec')
     type = if (inherits(spec, 'pkg_spec')) 'package' else 'module'
-    cat(sprintf('<%s: %s>\n', type, spec_name(spec)))
+    cat(fmt('<{type}: {spec_name(spec)}>\n'))
     invisible(x)
 }
 

--- a/R/errors.r
+++ b/R/errors.r
@@ -1,22 +1,48 @@
-#' Pretty-print error call to be informative for the user.
+#' Throw informative error messages
 #'
-#' @param error an object of class \code{c("error", "condition")} to rethrow
-#' @param call the calling context to rethrow the error from, overwriting the
-#' error’s current call object
+#' Helpers to generate readable and informative error messages for package
+#' users.
+#' @param \dots arguments to be passed to \code{fmt}
+#' @param call the calling context from which the error is raised
+#' @param subclass an optional subclass name for the error condition to be
+#' raised
+#'
+#' @details
+#' For \code{rethrow}, the \code{call} argument overrides the rethrown error’s
+#' own stored call.
 #' @keywords internal
+throw = function (..., call = sys.call(sys.parent()), subclass = NULL) {
+    message = fmt(..., envir = parent.frame())
+    stop(box_error(message, call = call, subclass = subclass))
+}
+
+#' @param error an object of class \code{c("error", "condition")} to rethrow
+#' @rdname throw
 rethrow = function (error, call = sys.call(sys.parent())) {
-    message = sprintf(
-        '%s\n(inside %s)',
-        conditionMessage(error),
-        paste(dQuote(deparse(conditionCall(error))), collapse = '\n')
+    throw(
+        '{msg}\n(inside {calls})',
+        msg = conditionMessage(error),
+        calls = paste(dQuote(deparse(conditionCall(error))), collapse = '\n'),
+        call = call,
+        subclass = setdiff(class(error), box_error_class)
     )
-    stop(simpleError(message, call))
 }
 
 #' @param expr an expression to evaluate inside \code{tryCatch}
 #' @return If it does not throw an error, \code{rethrow_on_error} returns the
 #' value of evaluating \code{expr}.
-#' @rdname rethrow
+#' @rdname throw
 rethrow_on_error = function (expr, call = sys.call(sys.parent())) {
     tryCatch(expr, error = function (error) rethrow(error, call))
+}
+
+box_error_class = c('box_error', 'error', 'condition')
+
+#' @param message the error message
+#' @return \code{box_error} returns a new \sQuote{box} error condition object
+#' with a given message and call, and optionally a given subclass type.
+#' @rdname throw
+box_error = function (message, call = NULL, subclass = NULL) {
+    class = c(subclass, box_error_class)
+    structure(list(message = message, call = call), class = class)
 }

--- a/R/format.r
+++ b/R/format.r
@@ -1,0 +1,114 @@
+#' String formatting helpers
+#'
+#' Interpolate expressions in a string
+#' @param \dots one or more unnamed character string arguments, followed
+#' optionally by named arguments
+#' @param x an object to convert
+#' @param a a character vector of length \code{n}
+#' @param b a character vector of length \code{n - 1}
+#' @return \code{fmt(\dots)} concatenates any unnamed arguments, and
+#' interpolates all embedded expressions as explained in the \sQuote{Details}.
+#' Named arguments are treated as locally defined variables, and are added to
+#' (and override, in case of name reuse) names defined in the calling scope.
+#' \code{chr(x)} returns a string representation of a value or unevaluated
+#' expression \code{x}.
+#' \code{interleave(a, b)} returns a vector \code{c(a[1], b[1], a[2], b[2],
+#' \dots, a[n - 1], b[n - 1], a[n])}.
+#' @details
+#' \code{fmt} interpolates embedded expressions in a string.
+#' \code{chr} converts a value to a character vector; unlike
+#' \code{as.character}, it correctly deparses unevaluated names and expressions.
+#' \code{interleave} is a helper that interleaves two vectors \code{a = c(a[1],
+#' \dots, a[n])} and \code{b = c(b[1], \dots, b[n - 1])}.
+#'
+#' The general format of an interpolation expression inside a \code{fmt} string
+#' is: \code{\{\dots\}} interpolates the expression \code{\dots}. To insert
+#' literal braces, double them (i.e. \code{\{\{}, \code{\}\}}). Interpolated
+#' expressions can optionally be followed by a \emph{format modifier}: if
+#' present, it is specified via the syntax \code{\{\dots;modifier\}}. The
+#' following modifiers are supported:
+#' \describe{
+#'  \item{\code{\"}}{like \code{dQuote(\dots)}}
+#'  \item{\code{\'}}{like \code{sQuote(\dots)}}
+#'  \item{\code{‹fmt›f}}{like \code{sprintf('\%‹fmt›f', \dots)}}
+#' }
+#' Vectors of length > 1 will be concatenated as if using
+#' \code{\link[base]{toString}} before interpolation.
+#' @keywords internal
+fmt = function (..., envir = parent.frame()) {
+    dots = list(...)
+    named = nzchar(names(dots))
+    str = paste(unlist(dots[(! named) %||% TRUE]), collapse = '')
+    vars = list2env(dots[named], parent = envir)
+
+    matches = gregexpr(
+        '(?<op>\\{\\{)|(?<cp>\\}\\})|\\{(?<expr>[^};]+)(;(?<mod>[^}]+))?\\}',
+        str,
+        perl = TRUE
+    )[[1L]]
+
+    if (matches[[1L]] == -1L) return(str)
+
+    glue = regmatches(str, list(matches), invert = TRUE)[[1L]]
+    pos = attr(matches, 'capture.start')
+    len = attr(matches, 'capture.length')
+    what = attr(matches, 'capture.names')[apply(pos, 1L, Position, f = identity)]
+
+    interp = map_chr(function (row) {
+        switch(
+            what[row],
+            op = '{',
+            cp = '}',
+            {
+                p = Find(identity, pos[row, ])
+                l = Find(identity, len[row, ])
+                expr = substr(str, p, p + l - 1L)
+                val = eval(parse(text = expr), envir = vars)
+
+                mod = pos[row, 'mod']
+                if (mod != 0L) {
+                    fmt = substr(str, mod, mod + len[row, 'mod'] - 1L);
+                    switch(
+                        substr(fmt, nchar(fmt), nchar(fmt)),
+                        `"` = toString(dQuote(chr(val))),
+                        `'` = toString(sQuote(chr(val))),
+                        f = sprintf(paste0('%', fmt), val),
+                        throw('unrecognized format modifier {fmt;"}')
+                    )
+                } else {
+                    paste(chr(val), collapse = ', ')
+                }
+            }
+        )
+    }, seq_along(what))
+
+    paste(interleave(glue, interp), collapse = '')
+}
+
+#' \code{chr}
+#' @rdname fmt
+chr = function (x) {
+    UseMethod('chr')
+}
+
+chr.default = function (x) {
+    as.character(x)
+}
+
+chr.call = function (x) {
+    deparse(x)
+}
+
+chr.expression = function (x) {
+    chr(x[[1L]])
+}
+
+chr.name = function (x) {
+    deparse(x, backtick = TRUE)
+}
+
+#' @rdname fmt
+interleave = function (a, b) {
+    index = order(c(seq_along(a), seq_along(b)))
+    c(a, b)[index]
+}

--- a/R/help.r
+++ b/R/help.r
@@ -21,10 +21,7 @@ help = function (topic, help_type = getOption('help_type', 'text')) {
     subject = target[[2L]]
 
     if (! inherits(target_mod, 'box$mod')) {
-        stop(
-            dQuote(deparse(topic)), ' is not a valid module help topic',
-            call. = FALSE
-        )
+        throw('{topic;"} is not a valid module help topic')
     }
 
     if (subject != '.__module__.') {
@@ -52,10 +49,7 @@ help = function (topic, help_type = getOption('help_type', 'text')) {
     }
 
     if (! requireNamespace('roxygen2')) {
-        stop(
-            sprintf('Displaying documentation requires %s installed', sQuote('roxygen2')),
-            call. = FALSE
-        )
+        throw('Displaying documentation requires {"roxygen2";\'} installed')
     }
 
     mod_ns = attr(target_mod, 'namespace')
@@ -70,16 +64,9 @@ help = function (topic, help_type = getOption('help_type', 'text')) {
 
     if (is.null(doc)) {
         if (subject == '.__module__.') {
-            stop(
-                'No documentation available for ', dQuote(mod_name),
-                call. = FALSE
-            )
+            throw('No documentation available for {mod_name;"}')
         } else {
-            stop(
-                'No documentation available for ', dQuote(subject),
-                ' in module ', dQuote(mod_name),
-                call. = FALSE
-            )
+            throw('No documentation available for {subject;"} in module {mod_name;"}')
         }
     }
 
@@ -160,13 +147,12 @@ help_topic_target = function (topic, caller) {
             mod = Recall(mod, expr[[2L]])
             as.character(expr[[3L]])
         } else {
-            stop(
-                dQuote(deparse(topic)), ' is not a valid module help topic',
-                call. = FALSE
-            )
+            throw('{topic;"} is not a valid module help topic', call = call)
         }
         get(name, envir = mod)
     }
+
+    call = sys.call(-1L)
 
     if (is.name(topic)) {
         obj = inner_mod(caller, topic)

--- a/R/info.r
+++ b/R/info.r
@@ -32,16 +32,13 @@ pkg_info = function (spec) {
 
 #' @export
 `as.character.box$mod_info` = function (x, ...) {
-    sprintf(
-        '<mod_info: \x1B[33m%s\x1B[0m at \x1B[33m%s\x1B[0m>',
-        x$name, x$source_path
-    )
+    fmt('<mod_info: \x1B[33m{x$name}\x1B[0m at \x1B[33m{x$source_path}\x1B[0m>')
 }
 
 #' @export
 `as.character.box$pkg_info` = function (x, ...) {
     path = getNamespaceInfo(x$name, 'path')
-    sprintf('<mod_info: \x1B[33m%s\x1B[0m>', path)
+    fmt('<mod_info: \x1B[33m{path}\x1B[0m>')
 }
 
 is_absolute = function (spec) {

--- a/R/info.r
+++ b/R/info.r
@@ -89,9 +89,9 @@ find_in_path = function (spec, base_paths) {
     which_base = which(map_lgl(any, hits))[1L]
 
     if (is.na(which_base)) {
-        stop(
-            'Unable to load module ', dQuote(spec_name(spec)),
-            '; not found in ', paste(dQuote(base_paths), collapse = ', ')
+        throw(
+            'Unable to load module {spec_name(spec);"}; ',
+            'not found in {base_paths;"}'
         )
     }
 

--- a/R/paths.r
+++ b/R/paths.r
@@ -78,7 +78,7 @@ script_path = function () {
             return(path)
         }
     }
-    stop('Unreachable code')
+    throw('Unreachable code')
 }
 
 #' @return \code{explicit_path} returns the script path explicitly set by the

--- a/R/spec.r
+++ b/R/spec.r
@@ -272,8 +272,5 @@ parse_error = function (...) {
             as.character(x)
         }
     }
-    stop(simpleError(
-        paste(map_chr(chr, list(...)), collapse = ''),
-        call = sys.call(-1L)
-    ))
+    throw(map_chr(chr, list(...)), call = sys.call(-1L))
 }

--- a/R/spec.r
+++ b/R/spec.r
@@ -85,10 +85,7 @@ spec_name = function (spec) {
     r_name = function (names) {
         map_chr(
             function (n) {
-                if (is.na(n)) '\u2026' else sprintf(
-                    '\x1b[33m%s\x1b[0m',
-                    deparse(as.name(n), backtick = TRUE)
-                )
+                if (is.na(n)) '\u2026' else fmt('\x1b[33m{as.name(n)}\x1b[0m')
             },
             names
         )
@@ -113,17 +110,15 @@ spec_name = function (spec) {
     mod_or_pkg = function (spec) {
         if (inherits(spec, 'box$mod_spec')) {
             prefix = paste(r_name(spec$prefix), collapse = '/')
-            sprintf('mod(%s/\x1b[4;33m%s\x1b[0m)', prefix, r_name(spec$name))
+            fmt('mod({prefix}/\x1b[4;33m{r_name(spec$name)}\x1b[0m)')
         } else {
-            sprintf('pkg(\x1b[4;33m%s\x1b[0m)', r_name(spec$name))
+            fmt('pkg(\x1b[4;33m{r_name(spec$name)}\x1b[0m)')
         }
     }
 
-    sprintf(
-        'mod_spec(%s%s%s)',
-        if (x$explicit) paste(r_name(x$alias), '= ') else '',
-        mod_or_pkg(x),
-        format_attach(x$attach)
+    fmt(
+        'mod_spec({alias}{mod_or_pkg(x)}{format_attach(x$attach)})',
+        alias = if (x$explicit) paste(r_name(x$alias), '= ') else ''
     )
 }
 

--- a/R/unload.r
+++ b/R/unload.r
@@ -75,9 +75,9 @@ reload = function (mod) {
     unload_mod_recursive(mod_ns, info)
 
     on.exit({
-        warning(sprintf(
-            'Reloading module %s failed, attempting to restore the old instance.',
-            dQuote(deparse(substitute(mod)))
+        warning(fmt(
+            'Reloading module {mod;"} failed, attempting to restore the old instance.',
+            mod = substitute(mod)
         ))
         register_mod(info, mod_ns)
     })

--- a/R/use.r
+++ b/R/use.r
@@ -254,7 +254,7 @@ use_one = function (declaration, alias, caller) {
     # Permit empty expression resulting from trailing comma.
     if (identical(declaration, quote(expr =)) && identical(alias, '')) return()
     spec = parse_spec(declaration, alias)
-    info = rethrow_on_error(find_mod(spec, caller), sys.call(-1L))
+    info = rethrow_on_error(find_mod(spec, caller), call = sys.call(-1L))
     load_and_register(spec, info, caller)
 }
 
@@ -425,13 +425,12 @@ attach_list = function (spec, exports) {
     is_wildcard = is.na(spec$attach)
     name_spec = spec$attach[! is_wildcard]
 
-    if (! all(is_wildcard) && any((missing = ! name_spec %in% exports))) {
-        stop(sprintf(
-            'Name%s %s not exported by %s',
-            if (length(name_spec[missing]) > 1L) 's' else '',
-            paste(dQuote(name_spec[missing]), collapse = ', '),
-            spec_name(spec)
-        ))
+    if (! all(is_wildcard) && any((what = ! name_spec %in% exports))) {
+        missing = name_spec[what]
+        throw(
+            'Name{s} {missing;"} not exported by {spec_name(spec);"}',
+            s = if (length(missing) > 1L) 's' else ''
+        )
     }
 
     if (any(is_wildcard)) {

--- a/tests/testthat/helper-expect.r
+++ b/tests/testthat/helper-expect.r
@@ -39,6 +39,17 @@ expect_not_null = function (object, info = NULL, label = NULL) {
     testthat::expect_false(is.null(object), info = info, label = act$lab)
 }
 
+expect_box_error = function (object, regexp = NULL, class = NULL, ..., info = NULL, label = NULL) {
+    expect_error(
+        object = object,
+        regexp = regexp,
+        class = c(class, 'box_error'),
+        ...,
+        info = info,
+        label = label
+    )
+}
+
 expect_messages = function (object, has = NULL, has_not = NULL, info = NULL, label = NULL) {
     self = environment()
     messages = character(0L)

--- a/tests/testthat/test-format.r
+++ b/tests/testthat/test-format.r
@@ -1,0 +1,160 @@
+context('format')
+
+test_that('literal strings are unchanged', {
+    expect_equal(fmt('this is a test'), 'this is a test')
+    expect_equal(fmt('this', 'is', 'a', 'test'), 'thisisatest')
+    expect_equal(fmt(c('this', 'is'), 'a', 'test'), 'thisisatest')
+})
+
+test_that('escaping works', {
+    expect_equal(fmt('a {{test}}'), 'a {test}')
+    expect_equal(fmt('a {{{{test}}'), 'a {{test}')
+})
+
+test_that('interpolation works', {
+    expect_equal(fmt('a {"test"}'), 'a test')
+    expect_equal(fmt('a {{{"test"}}}'), 'a {test}')
+    x = 'test'
+    expect_equal(fmt('a {x}'), 'a test')
+    expect_equal(fmt('a {x}', x = 42L), 'a 42')
+})
+
+# test_that('escaping works inside interpolation', {
+#     expect_equal(fmt('{"{{test"}'), '{test')
+#     expect_equal(fmt('{"test}}"}'), 'test}')
+# })
+
+test_that('format modifiers work', {
+    expect_equal(fmt('a {"test";"}'), sprintf('a %s', dQuote('test')))
+    expect_equal(fmt("a {'test';'}"), sprintf('a %s', sQuote('test')))
+    expect_equal(fmt('pi = {pi;.2f}'), sprintf('pi = %.2f', pi))
+    x = 1 : 3
+    expect_equal(fmt('x = {x}'), 'x = 1, 2, 3')
+    expect_equal(fmt('{x;"}'), toString(dQuote(x)))
+})
+
+test_that('invalid formats raise an error', {
+    expect_error(
+        fmt('{12;1?}'),
+        sprintf('unrecognized format modifier %s', dQuote('1\\?'))
+    )
+})
+
+test_that('real use-cases from this package implementation work', {
+    old_opts = options(useFancyQuotes = FALSE)
+    on.exit(options(old_opts))
+
+    # errors.r
+
+    call = call('foo', 'bar', x = 1L)
+    error = simpleError('test', call)
+    expect_equal(
+        fmt(
+            '{msg}\n(inside {calls})',
+            msg = conditionMessage(error),
+            calls = paste(dQuote(deparse(conditionCall(error))), collapse = '\n')
+        ),
+        'test\n(inside "foo("bar", x = 1L)")'
+    )
+
+    fmt = '?'
+    expect_equal(
+        fmt('unrecognized format modifier {fmt;"}'),
+        'unrecognized format modifier "?"'
+    )
+
+    # export.r
+
+    expect_equal(
+        fmt('{"export";"} can only be called from inside a module'),
+        '"export" can only be called from inside a module'
+    )
+
+    name = quote(test)
+    expect_equal(
+        fmt(
+            '{"export()";"} requires a list of unquoted names; ',
+            '{name;"} is not a name'
+        ),
+        '"export()" requires a list of unquoted names; "test" is not a name',
+    )
+
+    expect_equal(
+        fmt(
+            'Invalid attempt to export names from an incompletely ',
+            'loaded, cyclic import (module {name;"}) in line {line}.',
+            name = 'foo/test',
+            line = 42L
+        ),
+        'Invalid attempt to export names from an incompletely loaded, cyclic import (module "foo/test") in line 42.'
+    )
+
+    expect_equal(
+        fmt(
+            'The {"@export";"} tag may only be applied to assignments or ',
+            '{"use";"} declarations.\n',
+            'Used incorrectly in line {location}:\n',
+            '    {paste(code, collapse = \'\n    \')}',
+            code = c('foo', 'bar'),
+            location = 42L
+        ),
+        'The "@export" tag may only be applied to assignments or "use" declarations.\nUsed incorrectly in line 42:\n    foo\n    bar'
+    )
+
+    # help.r
+
+    topic = quote(foo$bar)
+    expect_equal(
+        fmt('{topic;"} is not a valid module help topic'),
+        '"foo$bar" is not a valid module help topic'
+    )
+
+    expect_equal(
+        fmt('Displaying documentation requires {"roxygen2";\'} installed'),
+        'Displaying documentation requires \'roxygen2\' installed'
+    )
+
+    mod_name = 'foo'
+    expect_equal(
+        fmt('No documentation available for {mod_name;"}'),
+        'No documentation available for "foo"'
+    )
+
+    subject = 'bar'
+    expect_equal(
+        fmt('No documentation available for {subject;"} in module {mod_name;"}'),
+        'No documentation available for "bar" in module "foo"'
+    )
+
+    # info.r
+
+    mod_name = 'foo/bar'
+    base_paths = c('foo', 'bar', 'baz')
+    expect_equal(
+        fmt(
+            'Unable to load module {mod_name;"}; ',
+            'not found in {base_paths;"}'
+        ),
+        'Unable to load module "foo/bar"; not found in "foo", "bar", "baz"',
+    )
+
+    # use.r
+
+    missing = 'foo'
+    expect_equal(
+        fmt(
+            'Name{s} {missing;"} not exported by {mod_name;"}',
+            s = if (length(missing) > 1L) 's' else ''
+        ),
+        'Name "foo" not exported by "foo/bar"',
+    )
+
+    missing = c('foo', 'bar')
+    expect_equal(
+        fmt(
+            'Name{s} {missing;"} not exported by {mod_name;"}',
+            s = if (length(missing) > 1L) 's' else ''
+        ),
+        'Names "foo", "bar" not exported by "foo/bar"'
+    )
+})

--- a/tests/testthat/test-format.r
+++ b/tests/testthat/test-format.r
@@ -34,7 +34,7 @@ test_that('format modifiers work', {
 })
 
 test_that('invalid formats raise an error', {
-    expect_error(
+    expect_box_error(
         fmt('{12;1?}'),
         sprintf('unrecognized format modifier %s', dQuote('1\\?'))
     )

--- a/tests/testthat/test-parse-mod-spec.r
+++ b/tests/testthat/test-parse-mod-spec.r
@@ -24,7 +24,7 @@ test_that('modules without attaching can be parsed', {
 })
 
 test_that('parse errors are correctly handled', {
-    expect_error(
+    expect_box_error(
         test_use(foo/bar[]),
         '^Expected at least one identifier in attach list'
     )
@@ -79,29 +79,29 @@ test_that('imports can be relative', {
 })
 
 test_that('`./` can only be used as a prefix', {
-    expect_error(test_use(a/./b), 'can only be used as a prefix')
-    expect_error(test_use(././b), 'can only be used as a prefix')
-    expect_error(test_use(a/b/.), 'can only be used as a prefix')
-    expect_error(test_use(a/./b[foo]), 'can only be used as a prefix')
-    expect_error(test_use(././b[foo]), 'can only be used as a prefix')
-    expect_error(test_use(a/b/.[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(a/./b), 'can only be used as a prefix')
+    expect_box_error(test_use(././b), 'can only be used as a prefix')
+    expect_box_error(test_use(a/b/.), 'can only be used as a prefix')
+    expect_box_error(test_use(a/./b[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(././b[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(a/b/.[foo]), 'can only be used as a prefix')
 
-    expect_error(test_use(../../b), NA)
-    expect_error(test_use(.././b), 'can only be used as a prefix')
-    expect_error(test_use(../.), 'can only be used as a prefix')
-    expect_error(test_use(../../b[foo]), NA)
-    expect_error(test_use(.././b[foo]), 'can only be used as a prefix')
-    expect_error(test_use(../.[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(../../b), NA)
+    expect_box_error(test_use(.././b), 'can only be used as a prefix')
+    expect_box_error(test_use(../.), 'can only be used as a prefix')
+    expect_box_error(test_use(../../b[foo]), NA)
+    expect_box_error(test_use(.././b[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(../.[foo]), 'can only be used as a prefix')
 
-    expect_error(test_use(a/../b), 'can only be used as a prefix')
-    expect_error(test_use(a/b/..), 'can only be used as a prefix')
-    expect_error(test_use(a/../b[foo]), 'can only be used as a prefix')
-    expect_error(test_use(a/b/..[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(a/../b), 'can only be used as a prefix')
+    expect_box_error(test_use(a/b/..), 'can only be used as a prefix')
+    expect_box_error(test_use(a/../b[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(a/b/..[foo]), 'can only be used as a prefix')
 
-    expect_error(test_use(./../b), 'can only be used as a prefix')
-    expect_error(test_use(./..), 'can only be used as a prefix')
-    expect_error(test_use(./../b[foo]), 'can only be used as a prefix')
-    expect_error(test_use(./..[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(./../b), 'can only be used as a prefix')
+    expect_box_error(test_use(./..), 'can only be used as a prefix')
+    expect_box_error(test_use(./../b[foo]), 'can only be used as a prefix')
+    expect_box_error(test_use(./..[foo]), 'can only be used as a prefix')
 })
 
 test_that('modules can have explicit aliases', {
@@ -155,9 +155,9 @@ test_that('attached names can have aliases', {
 })
 
 test_that('exports and aliases can’t be duplicated', {
-    expect_error(test_use(foo/bar[a, b, a]), 'duplicate names')
-    expect_error(test_use(foo/bar[x = a, y = b, x = c]), 'duplicate names')
-    expect_error(test_use(foo/bar[..., ...]), 'duplicate names')
+    expect_box_error(test_use(foo/bar[a, b, a]), 'duplicate names')
+    expect_box_error(test_use(foo/bar[x = a, y = b, x = c]), 'duplicate names')
+    expect_box_error(test_use(foo/bar[..., ...]), 'duplicate names')
 
     m = test_use(foo/bar[x = a, a = b, b])
     expect_true(is_mod_spec(m))
@@ -175,8 +175,8 @@ test_that('wildcards can be mixed with aliases', {
 })
 
 test_that('wildcard can’t have alias', {
-    expect_error(test_use(foo/bar[x = ...]), 'cannot be aliased')
-    expect_error(test_use(foo/bar[x = a, y = ...]), 'cannot be aliased')
+    expect_box_error(test_use(foo/bar[x = ...]), 'cannot be aliased')
+    expect_box_error(test_use(foo/bar[x = a, y = ...]), 'cannot be aliased')
 })
 
 # … the same for packages.
@@ -236,9 +236,9 @@ test_that('attached names in packages can have aliases', {
 })
 
 test_that('exports and aliases can’t be duplicated', {
-    expect_error(test_use(foo[a, b, a]), 'duplicate names')
-    expect_error(test_use(foo[x = a, y = b, x = c]), 'duplicate names')
-    expect_error(test_use(foo[..., ...]), 'duplicate names')
+    expect_box_error(test_use(foo[a, b, a]), 'duplicate names')
+    expect_box_error(test_use(foo[x = a, y = b, x = c]), 'duplicate names')
+    expect_box_error(test_use(foo[..., ...]), 'duplicate names')
 
     m = test_use(foo[x = a, a = b, b])
     expect_true(is_pkg_spec(m))
@@ -255,6 +255,6 @@ test_that('wildcards can be mixed with aliases', {
 })
 
 test_that('wildcard can’t have alias', {
-    expect_error(test_use(foo[x = ...]), 'cannot be aliased')
-    expect_error(test_use(foo[x = a, y = ...]), 'cannot be aliased')
+    expect_box_error(test_use(foo[x = ...]), 'cannot be aliased')
+    expect_box_error(test_use(foo[x = a, y = ...]), 'cannot be aliased')
 })

--- a/tests/testthat/test-partial-attach.r
+++ b/tests/testthat/test-partial-attach.r
@@ -14,7 +14,7 @@ test_that('partial attach works globally', {
 })
 
 test_that('Invalid attach specifier raises error', {
-    expect_error(
+    expect_box_error(
         box::use(mod/a[foo, bar]),
         regexp = 'Names .* not exported by'
     )

--- a/tests/testthat/test-pkg.r
+++ b/tests/testthat/test-pkg.r
@@ -134,14 +134,14 @@ test_that('wildcard attachments can contain aliases', {
 })
 
 test_that('non-existent aliases raise error', {
-    expect_error(box::use(devtools[foobar123]))
-    expect_error(box::use(devtools[test = foobar123]))
-    expect_error(box::use(devtools[..., test = foobar123]))
+    expect_box_error(box::use(devtools[foobar123]))
+    expect_box_error(box::use(devtools[test = foobar123]))
+    expect_box_error(box::use(devtools[..., test = foobar123]))
 })
 
 test_that('only exported things can be attached', {
     expect_in('yesno', ls(getNamespace('devtools')))
-    expect_error(box::use(devtools[yesno]), 'not exported')
+    expect_box_error(box::use(devtools[yesno]), 'not exported')
 })
 
 test_that('packages that attach things are not aliased', {


### PR DESCRIPTION
Replace instances of `stop(sprintf(‹complex formatting code›))` with `throw(‹simpler formatting code›)` via the introduction of a `fmt` helper which implements simple string interpolation.