### PR TITLE
First draft of auto-reload functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box
 Title: Write Reusable, Composable and Modular R Code
-Version: 1.1.3
+Version: 1.1.3.9000
 Authors@R: c(
         person(
             'Konrad', 'Rudolph',

--- a/R/autoreload.r
+++ b/R/autoreload.r
@@ -82,15 +82,25 @@ autoreload = local({
     add_include = function (spec, caller) {
         spec = parse_spec(spec, '')
         info = find_mod(spec, caller)
-        self$excludes = setdiff(self$excludes, info$source_path)
-        self$includes = c(self$includes, info$source_path)
+
+        if (length(self$includes) > 0L) {
+            self$includes = c(self$includes, info$source_path)
+        } else if (length(self$excludes) > 0L) {
+            self$excludes = setdiff(self$excludes, info$source_path)
+        } else {
+            self$includes = info$source_path
+        }
     }
 
     add_exclude = function (spec, caller) {
         spec = parse_spec(spec, '')
         info = find_mod(spec, caller)
-        self$includes = setdiff(self$includes, info$source_path)
-        self$excludes = c(self$excludes, info$source_path)
+
+        if (length(self$includes) > 0L) {
+            self$includes = setdiff(self$includes, info$source_path)
+        } else {
+            self$excludes = c(self$excludes, info$source_path)
+        }
     }
 
     included = function (info) {

--- a/R/autoreload.r
+++ b/R/autoreload.r
@@ -185,12 +185,20 @@ autoreload = local({
     }
 
     needs_reloading = function (info, ns) {
+        UseMethod('needs_reloading')
+    }
+
+    `needs_reloading.box$mod_info` = function (info, ns) {
         included(info) && (
             is_file_modified(info, ns) || {
                 imports = namespace_info(ns, 'imports')
                 any(map_lgl(function (x) needs_reloading(x$info, x$ns), imports))
             }
         )
+    }
+
+    `needs_reloading.box$pkg_info` = function (info, ns) {
+        FALSE
     }
 
     reset()

--- a/R/autoreload.r
+++ b/R/autoreload.r
@@ -1,0 +1,137 @@
+#' Auto-reloading of modules on change
+#'
+#' @usage \special{box::enable_autoreload(..., include, exclude, on_access = FALSE)}
+#' @param ... ignored; present to force naming arguments
+#' @param include vector of unevaluated, qualified module names to auto-reload
+#'  (optional)
+#' @param exclude vector of unevaluates, qualified module names to auto-reload
+#'  (optional)
+#' @param on_access logical value specifying whether to reload modules every
+#'  time they are used, or only when they are being loaded via \code{box::use}.
+#' @return \code{enable_autoreload} is called for its side effect and does not
+#'  return a value.
+#' @details
+#' \code{include} and \code{exclude}, when given, are either single,
+#' unevaluated, qualified module names (e.g. \code{./a}; \code{my/mod}) or
+#' vectors of such module names (e.g. \code{c(./a, my/mod)}).
+#' @name auto-reload
+#' @export
+enable_autoreload = function (..., include, exclude, on_access = FALSE) {
+    autoreload$init(on_access)
+    includes = spec_list(substitute(include))
+    excludes = spec_list(substitute(exclude))
+    caller = parent.frame()
+    map(autoreload$add_include, includes, list(caller))
+    map(autoreload$add_exclude, excludes, list(caller))
+    invisible()
+}
+
+#' @rdname auto-reload
+#' @export
+disable_autoreload = function () {
+    autoreload$reset()
+    invisible()
+}
+
+#' @rdname auto-reload
+#' @export
+autoreload_include = function (...) {
+    caller = parent.frame()
+    includes = match.call(expand.dots = FALSE)$...
+    map(autoreload$add_include, includes, list(caller))
+    invisible()
+}
+
+#' @rdname auto-reload
+#' @export
+autoreload_exclude = function (...) {
+    caller = parent.frame()
+    excludes = match.call(expand.dots = FALSE)$...
+    map(autoreload$add_exclude, excludes, list(caller))
+    invisible()
+}
+
+spec_list = function (specs) {
+    if (identical(specs, quote(expr =))) {
+        list()
+    } else if (is.call(specs) && identical(specs[[1L]], quote(c))) {
+        specs[-1L]
+    } else {
+        list(specs)
+    }
+}
+
+autoreload = local({
+    self = environment()
+
+    init = function (on_access) {
+        reset()
+        if (on_access) {
+            throw('Not yet implemented')
+        } else {
+            self$is_mod_loaded = is_mod_loaded_reload
+        }
+    }
+
+    reset = function () {
+        self$includes = character()
+        self$excludes = character()
+        self$is_mod_loaded = is_mod_loaded_basic
+    }
+
+    add_include = function (spec, caller) {
+        spec = parse_spec(spec, '')
+        info = find_mod(spec, caller)
+        self$excludes = setdiff(self$excludes, info$source_path)
+        self$includes = c(self$includes, info$source_path)
+    }
+
+    add_exclude = function (spec, caller) {
+        spec = parse_spec(spec, '')
+        info = find_mod(spec, caller)
+        self$includes = setdiff(self$includes, info$source_path)
+        self$excludes = c(self$excludes, info$source_path)
+    }
+
+    included = function (info) {
+        path = info$source_path
+
+        if (length(includes) == 0L) {
+            ! path %in% excludes
+        } else {
+            path %in% includes
+        }
+    }
+
+    is_mod_loaded_basic = function (info) {
+        info$source_path %in% names(loaded_mods)
+    }
+
+    is_mod_loaded_reload = function (info) {
+        is_mod_loaded_basic(info) && ! needs_reloading(info)
+    }
+
+    needs_reloading = function (info) {
+        included(info) && is_file_modified(info)
+    }
+
+    reset()
+
+    self
+})
+
+add_timestamp = function (info) {
+    timestamp = file.mtime(info$source_path)
+    mod_timestamps[[info$source_path]] = timestamp
+}
+
+remove_timestamp = function (info) {
+    rm(list = info$source_path, envir = mod_timestamps)
+}
+
+is_file_modified = function (info) {
+    prev = mod_timestamps[[info$source_path]]
+    is.null(prev) || file.mtime(info$source_path) > prev
+}
+
+mod_timestamps = new.env(parent = emptyenv())

--- a/R/autoreload.r
+++ b/R/autoreload.r
@@ -67,16 +67,16 @@ autoreload = local({
     init = function (on_access) {
         reset()
         if (on_access) {
-            throw('Not yet implemented')
-        } else {
-            self$is_mod_loaded = is_mod_loaded_reload
+            self$export_env_class = export_env_class_reload
         }
+        self$is_mod_loaded = is_mod_loaded_reload
     }
 
     reset = function () {
         self$includes = character()
         self$excludes = character()
         self$is_mod_loaded = is_mod_loaded_basic
+        self$export_env_class = export_env_class_basic
     }
 
     add_include = function (spec, caller) {
@@ -111,6 +111,29 @@ autoreload = local({
         } else {
             path %in% includes
         }
+    }
+
+    extract = function (e1, e2) {
+        ns = attr(e1, 'namespace')
+        info = namespace_info(ns, 'info')
+        new_mod = if (needs_reloading(info, ns)) {
+            spec = attr(e1, 'spec')
+            parent = attr(e1, 'parent')
+            load_and_register(spec, info, parent)
+            get(spec$alias, envir = parent)
+        } else {
+            e1
+        }
+
+        strict_extract(new_mod, e2)
+    }
+
+    export_env_class_basic = function (info, ns) {
+        'box$mod'
+    }
+
+    export_env_class_reload = function (info) {
+        c(if (included(info)) 'box$autoreload', 'box$mod')
     }
 
     is_mod_loaded_basic = function (info) {

--- a/R/env.r
+++ b/R/env.r
@@ -153,11 +153,23 @@ make_export_env = function (info, spec, ns) {
     structure(
         new.env(parent = emptyenv()),
         name = paste0('mod:', spec_name(spec)),
-        class = autoreload$export_env_class(info),
+        class = export_env_class(info),
         spec = spec,
         info = info,
         namespace = ns
     )
+}
+
+export_env_class = function (info) {
+    UseMethod('export_env_class')
+}
+
+`export_env_class.box$mod_info` = function (info) {
+    autoreload$export_env_class(info)
+}
+
+`export_env_class.box$pkg_info` = function (info) {
+    'box$mod'
 }
 
 strict_extract = function (e1, e2) {

--- a/R/env.r
+++ b/R/env.r
@@ -215,17 +215,17 @@ find_import_env.environment = function (x, spec, info, mod_ns) {
 }
 
 import_into_env = function (to_env, to_names, from_env, from_names) {
-    for (i in seq_along(to_names)) {
+    foreach(function (from, to) {
         if (
-            exists(from_names[i], from_env, inherits = FALSE)
-            && bindingIsActive(from_names[i], from_env)
-            && ! inherits((fun = activeBindingFunction(from_names[i], from_env)), 'box$placeholder')
+            exists(from, from_env, inherits = FALSE)
+            && bindingIsActive(from, from_env)
+            && ! inherits((fun = activeBindingFunction(from, from_env)), 'box$placeholder')
         ) {
-            makeActiveBinding(to_names[i], fun, to_env)
+            makeActiveBinding(to, fun, to_env)
         } else {
-            assign(to_names[i], env_get(from_env, from_names[i]), envir = to_env)
+            assign(to, env_get(from_env, from), envir = to_env)
         }
-    }
+    }, from_names, to_names)
 }
 
 env_get = function (env, name) {

--- a/R/env.r
+++ b/R/env.r
@@ -153,7 +153,7 @@ make_export_env = function (info, spec, ns) {
     structure(
         new.env(parent = emptyenv()),
         name = paste0('mod:', spec_name(spec)),
-        class = 'box$mod',
+        class = autoreload$export_env_class(info),
         spec = spec,
         info = info,
         namespace = ns
@@ -175,6 +175,9 @@ strict_extract = function (e1, e2) {
 
 #' @export
 `$.box$ns` = strict_extract
+
+#' @export
+`$.box$autoreload` = autoreload$extract
 
 #' @export
 `print.box$mod` = function (x, ...) {

--- a/R/loaded.r
+++ b/R/loaded.r
@@ -41,7 +41,7 @@ register_mod = function (info, mod_ns) {
     # At worst, this means loading the module redundantly in auto-reload mode.
     # Doing it the other way round might cause file changes not to be noticed.
     add_timestamp(info)
-    attr(loaded_mods[[info$source_path]], 'loading') = TRUE
+    namespace_info(loaded_mods[[info$source_path]], 'loading') = TRUE
 }
 
 #' @rdname loaded
@@ -59,10 +59,10 @@ loaded_mod = function (info) {
 #' @rdname loaded
 is_mod_still_loading = function (info) {
     # pkg_info has no `source_path` but already finished loading anyway.
-    ! is.null(info$source_path) && attr(loaded_mods[[info$source_path]], 'loading')
+    ! is.null(info$source_path) && namespace_info(loaded_mods[[info$source_path]], 'loading')
 }
 
 #' @rdname loaded
 mod_loading_finished = function (info, mod_ns) {
-    attr(loaded_mods[[info$source_path]], 'loading') = FALSE
+    namespace_info(loaded_mods[[info$source_path]], 'loading') = FALSE
 }

--- a/R/loaded.r
+++ b/R/loaded.r
@@ -29,13 +29,18 @@ loaded_mods = new.env(parent = emptyenv())
 #' @param info the mod info of a module
 #' @rdname loaded
 is_mod_loaded = function (info) {
-    info$source_path %in% names(loaded_mods)
+    autoreload$is_mod_loaded(info)
 }
 
 #' @param mod_ns module namespace environment
 #' @rdname loaded
 register_mod = function (info, mod_ns) {
     loaded_mods[[info$source_path]] = mod_ns
+    # The timestamp is saved *before* the source file is loaded to prevent race
+    # conditions in the presence of concurrent file modifications.
+    # At worst, this means loading the module redundantly in auto-reload mode.
+    # Doing it the other way round might cause file changes not to be noticed.
+    add_timestamp(info)
     attr(loaded_mods[[info$source_path]], 'loading') = TRUE
 }
 

--- a/R/loaded.r
+++ b/R/loaded.r
@@ -40,7 +40,7 @@ register_mod = function (info, mod_ns) {
     # conditions in the presence of concurrent file modifications.
     # At worst, this means loading the module redundantly in auto-reload mode.
     # Doing it the other way round might cause file changes not to be noticed.
-    add_timestamp(info)
+    add_timestamp(info, mod_ns)
     namespace_info(loaded_mods[[info$source_path]], 'loading') = TRUE
 }
 

--- a/R/map.r
+++ b/R/map.r
@@ -8,6 +8,8 @@
 #' \sQuote{Examples}).
 #' \code{transpose} is a special \code{map} application that concatenates its
 #' inputs to compute a transposed list.
+#' \code{foreach} is a special \code{map} application that does not return a
+#' value; it is therefore expected that \code{.f} causes a side-effect.
 #' @param .f an n-ary function where n is the number of further arguments given
 #' @param \dots lists of arguments to map over in parallel
 #' @param .default the default value returned by \code{flatmap} for an empty
@@ -76,4 +78,13 @@ map_chr = function (.f, ...) {
 #' @rdname map
 transpose = function (...) {
     map(c, ...)
+}
+
+#' @return \code{foreach} does not return any value.
+#' @rdname map
+foreach = function (.f, ...) {
+    args = list(...)
+    for (i in seq_along(..1)) {
+        do.call(.f, lapply(args, `[[`, i))
+    }
 }

--- a/R/use.r
+++ b/R/use.r
@@ -499,6 +499,7 @@ assign_alias = function (spec, mod_exports, caller) {
     if (exists(spec$alias, caller, inherits = FALSE) && bindingIsLocked(spec$alias, caller)) {
         box_unlock_binding(spec$alias, caller)
     }
+    attr(mod_exports, 'parent') = caller
     assign(spec$alias, mod_exports, envir = caller)
 }
 

--- a/R/use.r
+++ b/R/use.r
@@ -455,7 +455,11 @@ attach_to_caller = function (spec, info, mod_exports, mod_ns, caller) {
 
     import_env = find_import_env(caller, spec, info, mod_ns)
     attr(mod_exports, 'attached') = environmentName(import_env)
-    import_into_env(import_env, names(attach_list), mod_exports, attach_list)
+    autoreload$import_into_env(
+        spec, info,
+        import_env, names(attach_list),
+        mod_ns, attach_list
+    )
 }
 
 #' @return \code{attach_list} returns a named character vector of the names in

--- a/tests/testthat/helper-debug.r
+++ b/tests/testthat/helper-debug.r
@@ -2,6 +2,14 @@ clear_mods = function () {
     rm(list = names(box:::loaded_mods), envir = box:::loaded_mods)
 }
 
+# Undo “user-friendly” stack traces to make them more useful.
+utils::assignInNamespace(
+    'rethrow_on_error',
+    function (expr, call) expr,
+    ns = getNamespace('box'),
+    envir = getNamespace('box')
+)
+
 .setup_fun = NULL
 .teardown_fun = NULL
 

--- a/tests/testthat/test-autoreload.r
+++ b/tests/testthat/test-autoreload.r
@@ -14,6 +14,8 @@ create_simple_test_module = function (dir) {
 }
 
 edit_simple_test_module = function (dir) {
+    # Ensure file modification timestamp is different.
+    Sys.sleep(0.001)
     a = file.path(dir, 'mod', 'a.r')
     writeLines(c("#' @export", 'f = function () 2L'), a)
 }
@@ -31,6 +33,8 @@ create_dependent_test_module = function (dir) {
 }
 
 edit_dependent_test_module = function (dir) {
+    # Ensure file modification timestamp is different.
+    Sys.sleep(0.001)
     mod = file.path(dir, 'mod')
     writeLines(c("#' @export", 'f = function () 2L'), file.path(mod, 'b.r'))
 }

--- a/tests/testthat/test-autoreload.r
+++ b/tests/testthat/test-autoreload.r
@@ -10,7 +10,11 @@ create_simple_test_module = function (dir) {
     mod = file.path(dir, 'mod')
     dir.create(mod)
     a = file.path(mod, 'a.r')
-    writeLines(c("#' @export", 'f = function () 1L'), a)
+    writeLines(c(
+        'box::use(stats)',
+        "#' @export",
+        'f = function () 1L'
+    ), a)
 }
 
 edit_simple_test_module = function (dir) {

--- a/tests/testthat/test-autoreload.r
+++ b/tests/testthat/test-autoreload.r
@@ -1,0 +1,220 @@
+context('autoreload')
+
+tempfile_dir = function (...) {
+    file = tempfile()
+    dir.create(file)
+    file
+}
+
+create_simple_test_module = function (dir) {
+    mod = file.path(dir, 'mod')
+    dir.create(mod)
+    a = file.path(mod, 'a.r')
+    writeLines("#' @export\nf = function () 1L", a)
+}
+
+edit_simple_test_module = function (dir) {
+    a = file.path(dir, 'mod', 'a.r')
+    writeLines("#' @export\nf = function () 2L", a)
+}
+
+create_dependent_test_module = function (dir) {
+    mod = file.path(dir, 'mod')
+    dir.create(mod)
+    writeLines("#' @export\nbox::use(./b[f])", file.path(mod, 'a.r'))
+    writeLines("#' @export\nf = function () 1L", file.path(mod, 'b.r'))
+}
+
+edit_dependent_test_module = function (dir) {
+    mod = file.path(dir, 'mod')
+    writeLines("#' @export\nf = function () 2L", file.path(mod, 'b.r'))
+}
+
+test_teardown(box:::autoreload$reset())
+
+included = function (declaration) {
+    caller = parent.frame()
+    spec = parse_spec(substitute(declaration), '')
+    info = find_mod(spec, caller)
+    box:::autoreload$included(info)
+}
+
+test_that('no name needs to be specified', {
+    expect_error(box::enable_autoreload(), NA)
+})
+
+test_that('a single name can be specified', {
+    expect_error(box::enable_autoreload(include = mod/a), NA)
+    expect_error(box::enable_autoreload(exclude = mod/b), NA)
+
+    expect_error(box::autoreload_include(mod/a), NA)
+    expect_error(box::autoreload_exclude(mod/a), NA)
+})
+
+test_that('multiple names can be specified', {
+    expect_error(box::enable_autoreload(include = c(mod/a, mod/b)), NA)
+    expect_error(box::enable_autoreload(exclude = c(mod/a, mod/b)), NA)
+
+    expect_error(box::autoreload_include(mod/a, mod/b), NA)
+    expect_error(box::autoreload_exclude(mod/a, mod/b), NA)
+})
+
+test_that('all names are included by default', {
+    box::enable_autoreload()
+    expect_true(included(mod/a))
+    expect_true(included(mod/b))
+    expect_true(included(mod/b/a))
+    expect_true(included(mod/b/b))
+})
+
+test_that('included names are excluded', {
+    box::enable_autoreload(include = c(mod/a, mod/b, mod/b/a))
+    expect_true(included(mod/a))
+    expect_true(included(mod/b))
+    expect_true(included(mod/b/a))
+    expect_false(included(mod/b/b))
+})
+
+test_that('excluded names are not included', {
+    box::enable_autoreload(exclude = c(mod/a, mod/b, mod/b/a))
+    expect_false(included(mod/a))
+    expect_false(included(mod/b))
+    expect_false(included(mod/b/a))
+    expect_true(included(mod/b/b))
+})
+
+test_that('names can be included after being excluded', {
+    box::enable_autoreload(exclude = c(mod/a, mod/b, mod/b/a))
+    box::autoreload_include(mod/a, mod/b/a)
+    expect_true(included(mod/a))
+    expect_false(included(mod/b))
+    expect_true(included(mod/b/a))
+    expect_true(included(mod/b/b))
+})
+
+test_that('names can be excluded after being included', {
+    box::enable_autoreload(include = c(mod/a, mod/b, mod/b/a))
+    box::autoreload_exclude(mod/a, mod/b/a)
+    expect_false(included(mod/a))
+    expect_true(included(mod/b))
+    expect_false(included(mod/b/a))
+    expect_false(included(mod/b/b))
+})
+
+test_that('auto-reloading simple modules works with `box::use`', {
+    dir = tempfile_dir()
+    on.exit(unlink(dir, recursive = TRUE))
+
+    old_path = options(box.path = dir)
+    on.exit(options(old_path), add = TRUE)
+
+    create_simple_test_module(dir)
+
+    box::enable_autoreload()
+    box::use(mod/a)
+
+    expect_equal(a$f(), 1L)
+
+    edit_simple_test_module(dir)
+
+    box::use(mod/a)
+
+    expect_equal(a$f(), 2L)
+})
+
+test_that('auto-reloading dependent modules works with `box::use`', {
+    dir = tempfile_dir()
+    on.exit(unlink(dir, recursive = TRUE))
+
+    old_path = options(box.path = dir)
+    on.exit(options(old_path), add = TRUE)
+
+    create_dependent_test_module(dir)
+
+    box::enable_autoreload()
+    box::use(mod/a)
+
+    expect_equal(a$f(), 1L)
+
+    edit_dependent_test_module(dir)
+
+    box::use(mod/a)
+
+    expect_equal(a$f(), 2L)
+})
+
+test_that('auto-reloading simple modules works with module name', {
+    dir = tempfile_dir()
+    on.exit(unlink(dir, recursive = TRUE))
+
+    old_path = options(box.path = dir)
+    on.exit(options(old_path), add = TRUE)
+
+    create_simple_test_module(dir)
+
+    box::enable_autoreload(on_access = TRUE)
+    box::use(mod/a)
+
+    expect_equal(a$f(), 1L)
+
+    edit_simple_test_module(dir)
+
+    expect_equal(a$f(), 2L)
+})
+
+test_that('auto-reloading dependent modules works with module name', {
+    dir = tempfile_dir()
+    on.exit(unlink(dir, recursive = TRUE))
+
+    old_path = options(box.path = dir)
+    on.exit(options(old_path), add = TRUE)
+
+    create_dependent_test_module(dir)
+
+    box::enable_autoreload(on_access = TRUE)
+    box::use(mod/a)
+
+    expect_equal(a$f(), 1L)
+
+    edit_dependent_test_module(dir)
+
+    expect_equal(a$f(), 2L)
+})
+
+test_that('auto-reloading simple modules works with attached name', {
+    dir = tempfile_dir()
+    on.exit(unlink(dir, recursive = TRUE))
+
+    old_path = options(box.path = dir)
+    on.exit(options(old_path), add = TRUE)
+
+    create_simple_test_module(dir)
+
+    box::enable_autoreload(on_access = TRUE)
+    box::use(mod/a[f])
+
+    expect_equal(f(), 1L)
+
+    edit_simple_test_module(dir)
+
+    expect_equal(f(), 2L)
+})
+
+test_that('auto-reloading dependent modules works with attached name', {
+    dir = tempfile_dir()
+    on.exit(unlink(dir, recursive = TRUE))
+
+    old_path = options(box.path = dir)
+    on.exit(options(old_path), add = TRUE)
+
+    create_dependent_test_module(dir)
+
+    box::enable_autoreload(on_access = TRUE)
+    box::use(mod/a[f])
+
+    expect_equal(f(), 1L)
+
+    edit_dependent_test_module(dir)
+
+    expect_equal(f(), 2L)
+})

--- a/tests/testthat/test-reload.r
+++ b/tests/testthat/test-reload.r
@@ -4,11 +4,6 @@ is_module_loaded = function (path) {
     path %in% names(box:::loaded_mods)
 }
 
-unload_all = function () {
-    modenv = box:::loaded_mods
-    rm(list = names(modenv), envir = modenv)
-}
-
 tempfile_dir = function (...) {
     file = tempfile()
     dir.create(file)
@@ -28,10 +23,6 @@ edit_nested_test_module = function (dir) {
 }
 
 test_that('module can be reloaded', {
-    # Required since other tests have side-effects.
-    # Tear-down would be helpful here, but not supported by testthat.
-    unload_all()
-
     box::use(mod/a)
     expect_equal(length(box:::loaded_mods), 1L)
     counter = a$get_counter()


### PR DESCRIPTION
Work in progress implementation of #234.

The first draft includes auto-reloading for subsequent `box::use` calls:

* `box::enable_autoreload()` enables auto-reloading for `box::use` calls only. This solution should work e.g. for Shiny applications. But it *won’t* work well inside scripts and R Markdown documents, since `box::use` is required to trigger a reload.
* `box::disable_autoreload()` disables auto-reloading.
* `box::enable_autoreload` accepts `include` and `exclude` arguments to limit which modules get auto-reloaded:
  * `box::enable_autoreload(include = c(./a, my/mod, foo/bar))`
  *  or a single module, `box::enable_autoreload(include = foo/bar)`
  *  same for `exclude`
* `box::autoreload_include(...)` and `box::autoreload_exclude(...)` add includes or excludes after auto-reloading has been enabled
* only “top-level” changes are tracked, not module dependencies; this means that, if `./a` imports `./b` and `b.r` changes, then `box::use(./a)` won’t reload either `a.r` or `b.r`, since only the (unchanged) timestamp of `a.r` is checked.

Well, that’s about it for now.

Still to be done:

* [x] implement tests
* [ ] implement reloading for module dependency changes
* [x] implement auto-reloading for qualified module access (`mod$x`)
* [x] implement auto-reloading for access of attached module objects
* [ ] finalise API design
* [ ] handle module namespace hooks  (how?) — the current draft only runs `.on_load`

/cc @grst for feedback