### PR TITLE
PR for #307

### DIFF
--- a/R/use.r
+++ b/R/use.r
@@ -294,6 +294,7 @@ use_one = function (declaration, alias, caller, use_call) {
     if (identical(declaration, quote(expr =)) && identical(alias, '')) return()
 
     rethrow_on_error({
+      browser()
         spec = parse_spec(declaration, alias)
         info = find_mod(spec, caller)
         load_and_register(spec, info, caller)

--- a/R/use.r
+++ b/R/use.r
@@ -294,7 +294,6 @@ use_one = function (declaration, alias, caller, use_call) {
     if (identical(declaration, quote(expr =)) && identical(alias, '')) return()
 
     rethrow_on_error({
-      browser()
         spec = parse_spec(declaration, alias)
         info = find_mod(spec, caller)
         load_and_register(spec, info, caller)


### PR DESCRIPTION
Small edits that make feature request in #307 possible. First, `find_mod.box$pkg_spec` will try and search for the package eagerly to see if it exists. Otherwise it assumes it is really a module. A small edit has been made to `mod_file_candidates()` switching out the base `file.path` for internal function `file_path` which removes zero length arguments. zero length arguments in `file.path` will cause the function to return a zero length character vector. This allows `find_global_mod` to find a mod that is pkg like  and does not have a prefix attribute. 