### PR TITLE
New feature: unscoped module names

### DIFF
--- a/R/info.r
+++ b/R/info.r
@@ -41,8 +41,8 @@ pkg_info = function (spec) {
     fmt('<mod_info: \x1B[33m{path}\x1B[0m>')
 }
 
-is_absolute = function (spec) {
-    spec$prefix[1L] %in% c('.', '..')
+is_local = function (spec) {
+    ! is.null(spec$prefix) && spec$prefix[1L] %in% c('.', '..')
 }
 
 find_mod = function (spec, caller) {
@@ -50,7 +50,7 @@ find_mod = function (spec, caller) {
 }
 
 `find_mod.box$mod_spec` = function (spec, caller) {
-    if (is_absolute(spec)) find_local_mod(spec, caller) else find_global_mod(spec, caller)
+    if (is_local(spec)) find_local_mod(spec, caller) else find_global_mod(spec, caller)
 }
 
 `find_mod.box$pkg_spec` = function (spec, caller) {
@@ -98,7 +98,8 @@ find_in_path = function (spec, base_paths) {
 }
 
 mod_file_candidates = function (spec, base_paths) {
-    mod_path_prefix = merge_path(spec$prefix)
+    # Fallback for unscoped, global module names.
+    mod_path_prefix = merge_path(spec$prefix) %||% '.'
     ext = c('.r', '.R')
     simple_mod = file.path(mod_path_prefix, paste0(spec$name, ext))
     nested_mod = file.path(mod_path_prefix, spec$name, paste0('__init__', ext))

--- a/tests/testthat/helper-mod-spec.r
+++ b/tests/testthat/helper-mod-spec.r
@@ -1,0 +1,33 @@
+test_use = function (...) {
+    call = match.call()
+    parse_spec(call[[2L]], names(call)[[2L]] %||% '')
+}
+
+expect_identical_spec = function (object, expected) {
+    act = quasi_label(rlang::enquo(object), NULL, arg = 'object')
+    exp = quasi_label(rlang::enquo(expected), NULL, arg = 'expected')
+
+    ident = identical(act$val, exp$val)
+    msg = if (ident) {
+        ''
+    } else {
+        act_str = capture.output(str(unclass(act$val)))
+        exp_str = capture.output(str(unclass(exp$val)))
+        paste0(paste('  ', act_str, collapse = '\n'), '\n≠\n', paste('  ', exp_str, collapse = '\n'))
+    }
+
+    expect(
+        ident,
+        sprintf('%s not identical to %s:\n%s', act$lab, exp$lab, msg),
+        info = NULL
+    )
+    invisible(act$val)
+}
+
+is_mod_spec = function (x) {
+    inherits(x, 'box$mod_spec')
+}
+
+is_pkg_spec = function (x) {
+    inherits(x, 'box$pkg_spec')
+}

--- a/tests/testthat/test-find.r
+++ b/tests/testthat/test-find.r
@@ -98,3 +98,17 @@ test_that('modules are found during Shiny startup', {
     script_path = rscript('support/run-shiny.r')
     expect_paths_equal(script_path, 'support/shiny-app')
 })
+
+test_that('unscoped modules can be found', {
+    spec = parse_spec(quote(mod(a)), '')
+    candidates = mod_file_candidates(spec, 'x')
+    expect_setequal(
+        unlist(candidates),
+        c('x/./a.r', 'x/./a.R', 'x/./a/__init__.r', 'x/./a/__init__.R')
+    )
+
+    old_opts = options(box.path = file.path(getOption('box.path'), 'mod'))
+    on.exit(options(old_opts))
+
+    expect_error(find_mod(spec, environment()), NA)
+})


### PR DESCRIPTION
This PR is a WIP implementation of unscoped module names. For now, the syntax for specifying an unscoped module name `xyz` is `box::use(mod(xyz))`. `mod(…)` disambiguates between package and module names, and can be passed *any* module name, including scoped ones (both global and local, e.g. `mod(foo/bar)` and `mod(./foo)`).

The current placeholder syntax for disambiguation (i.e. `mod(…)`) is subject to change before the PR is merged. For suggestions, see discussion at #307.

For now I’ve narrowed this list down to the following candidates:

1. `box::use(mod:module_name)`
2. `box::use(mod::module_name)`

Feedback welcome.