### PR TITLE
Remove references to `Rf_findVarInFrame()` and `R_UnboundValue`

### DIFF
--- a/src/lookup.c
+++ b/src/lookup.c
@@ -29,32 +29,33 @@ SEXP strict_extract(SEXP e1, SEXP e2) {
     // Return value of `install` does not need to be protected:
     // <https://github.com/kalibera/cran-checks/blob/master/rchk/PROTECT.md>
     SEXP name = Rf_installTrChar(STRING_ELT(e2, 0));
-#if R_VERSION < R_Version(4,6,0)
+
+#if R_VERSION < R_Version(4, 6, 0)
     SEXP ret = Rf_findVarInFrame(e1, name);
     if (ret != R_UnboundValue) {
-        /* if ret is a promise, evaluate it */
         if (TYPEOF(ret) == PROMSXP) {
             PROTECT(ret);
-            ret = Rf_eval(ret, R_EmptyEnv);
+            ret = Rf_eval(ret, e1);
             UNPROTECT(1);
         }
         return ret;
     }
 #else
     SEXP ret = R_getVarEx(name, e1, /* inherits */ FALSE, /* ifnotfound */ NULL);
-    if (ret)
+    if (ret) {
         return ret;
+    }
 #endif
 
-        SEXP parent = PROTECT(parent_frame());
-        SEXP call = PROTECT(sys_call(parent));
-        SEXP fst_arg = PROTECT(CADR(call));
+    SEXP parent = PROTECT(parent_frame());
+    SEXP call = PROTECT(sys_call(parent));
+    SEXP fst_arg = PROTECT(CADR(call));
 
-        Rf_errorcall(
-            call, "name '%s' not found in '%s'",
-            Rf_translateChar(STRING_ELT(e2, 0)),
-            Rf_translateChar(PRINTNAME(fst_arg))
-        );
+    Rf_errorcall(
+        call, "name '%s' not found in '%s'",
+        Rf_translateChar(STRING_ELT(e2, 0)),
+        Rf_translateChar(PRINTNAME(fst_arg))
+    );
 }
 
 // Cached version of an R function that calls `sys.frame(-1L)`.

--- a/src/lookup.c
+++ b/src/lookup.c
@@ -41,12 +41,9 @@ SEXP strict_extract(SEXP e1, SEXP e2) {
         return ret;
     }
 #else
-    switch (R_GetBindingType(name, e1)) {
-    case R_BindingTypeUnbound:
-        break;
-    default:
-        return R_getVar(name, e1, /* inherits */ FALSE);
-    }
+    SEXP ret = R_getVarEx(name, e1, /* inherits */ FALSE, /* ifnotfound */ NULL);
+    if (ret)
+        return ret;
 #endif
 
         SEXP parent = PROTECT(parent_frame());

--- a/src/lookup.c
+++ b/src/lookup.c
@@ -29,14 +29,26 @@ SEXP strict_extract(SEXP e1, SEXP e2) {
     // Return value of `install` does not need to be protected:
     // <https://github.com/kalibera/cran-checks/blob/master/rchk/PROTECT.md>
     SEXP name = Rf_installTrChar(STRING_ELT(e2, 0));
-    SEXP ret =
-#if R_VERSION < R_Version(4, 5, 0)
-        Rf_findVarInFrame(e1, name);
+#if R_VERSION < R_Version(4,6,0)
+    SEXP ret = Rf_findVarInFrame(e1, name);
+    if (ret != R_UnboundValue) {
+        /* if ret is a promise, evaluate it */
+        if (TYPEOF(ret) == PROMSXP) {
+            PROTECT(ret);
+            ret = Rf_eval(ret, R_EmptyEnv);
+            UNPROTECT(1);
+        }
+        return ret;
+    }
 #else
-        R_getVarEx(name, e1, FALSE, R_UnboundValue);
+    switch (R_GetBindingType(name, e1)) {
+    case R_BindingTypeUnbound:
+        break;
+    default:
+        return R_getVar(name, e1, /* inherits */ FALSE);
+    }
 #endif
 
-    if (ret == R_UnboundValue) {
         SEXP parent = PROTECT(parent_frame());
         SEXP call = PROTECT(sys_call(parent));
         SEXP fst_arg = PROTECT(CADR(call));
@@ -46,9 +58,6 @@ SEXP strict_extract(SEXP e1, SEXP e2) {
             Rf_translateChar(STRING_ELT(e2, 0)),
             Rf_translateChar(PRINTNAME(fst_arg))
         );
-    }
-
-    return ret;
 }
 
 // Cached version of an R function that calls `sys.frame(-1L)`.


### PR DESCRIPTION
In R >= 4.6, remove references to `Rf_findVarInFrame()` and `R_UnboundValue` in favour of `R_GetBindingType()` and `R_getVar()`